### PR TITLE
feat: 优化按钮样式 - 象棋主题风格

### DIFF
--- a/lib/views/board_painter.dart
+++ b/lib/views/board_painter.dart
@@ -27,7 +27,7 @@ class BoardPainter extends CustomPainter {
 
   void _drawBackground(Canvas canvas, Size size) {
     // 木质底色
-    final paint = Paint()..color = const Color(0xFFDEB887);
+    final paint = Paint()..color = const Color(0xFFF5DEB3);
     canvas.drawRect(Rect.fromLTWH(0, 0, size.width, size.height), paint);
 
     // 细微木纹纹理效果

--- a/lib/views/game_view.dart
+++ b/lib/views/game_view.dart
@@ -15,6 +15,12 @@ const _kGoldLight = Color(0xFFD4A84B);
 const _kBamboo = Color(0xFFE8D5B0);
 const _kRedInk = Color(0xFFA01010);
 
+/// 按钮主色：深朱红
+const _kBtnPrimary = Color(0xFFC0392B);
+const _kBtnPrimaryDark = Color(0xFF922B21);
+const _kBtnPrimaryLight = Color(0xFFE74C3C);
+const _kBtnOutlineBorder = Color(0xFFD4A84B);
+
 class GameView extends GetView<GameController> {
   const GameView({super.key});
 
@@ -241,20 +247,9 @@ class GameView extends GetView<GameController> {
                                   fontWeight: FontWeight.bold,
                                   letterSpacing: 12)),
                           const SizedBox(height: 24),
-                          ElevatedButton(
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: _kGold,
-                              foregroundColor: _kParchment,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(8),
-                              ),
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 32, vertical: 12),
-                            ),
+                          _GamePrimaryButton(
+                            label: '继续对弈',
                             onPressed: () => controller.resumeGame(),
-                            child: const Text('继续对弈',
-                                style: TextStyle(
-                                    fontSize: 16, letterSpacing: 4)),
                           ),
                         ],
                       ),
@@ -289,6 +284,14 @@ class GameView extends GetView<GameController> {
                 style: const TextStyle(fontSize: 18, color: Color(0xFF5C3A1E))),
             actions: [
               TextButton(
+                style: TextButton.styleFrom(
+                  foregroundColor: _kBtnPrimary,
+                  textStyle: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    letterSpacing: 4,
+                  ),
+                ),
                 onPressed: () {
                   Get.back();
                   controller.resetBoard();
@@ -317,10 +320,26 @@ class GameView extends GetView<GameController> {
         content: const Text('确定要重新开始对弈吗？'),
         actions: [
           TextButton(
+            style: TextButton.styleFrom(
+              foregroundColor: _kGold,
+              textStyle: const TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 2,
+              ),
+            ),
             onPressed: () => Get.back(),
             child: const Text('取消'),
           ),
           TextButton(
+            style: TextButton.styleFrom(
+              foregroundColor: _kBtnPrimary,
+              textStyle: const TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.bold,
+                letterSpacing: 2,
+              ),
+            ),
             onPressed: () {
               Get.back();
               controller.resetBoard();
@@ -345,6 +364,14 @@ class GameView extends GetView<GameController> {
         content: const Text('当前对局将会丢失，确定返回吗？'),
         actions: [
           TextButton(
+            style: TextButton.styleFrom(
+              foregroundColor: _kGold,
+              textStyle: const TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 2,
+              ),
+            ),
             onPressed: () {
               Get.back();
               controller.resumeGame();
@@ -352,6 +379,14 @@ class GameView extends GetView<GameController> {
             child: const Text('继续对弈'),
           ),
           TextButton(
+            style: TextButton.styleFrom(
+              foregroundColor: _kBtnPrimary,
+              textStyle: const TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.bold,
+                letterSpacing: 2,
+              ),
+            ),
             onPressed: () {
               Get.back();
               Get.back();
@@ -435,6 +470,14 @@ class GameView extends GetView<GameController> {
         ),
         actions: [
           TextButton(
+            style: TextButton.styleFrom(
+              foregroundColor: _kBtnPrimary,
+              textStyle: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                letterSpacing: 4,
+              ),
+            ),
             onPressed: () => Get.back(),
             child: const Text('知晓'),
           ),
@@ -471,7 +514,7 @@ class _RuleSection extends StatelessWidget {
   }
 }
 
-/// 底部功能按钮
+/// 底部功能按钮（升级版：启用态深朱红边框 + 阴影，禁用态淡出）
 class _ActionButton extends StatelessWidget {
   final IconData icon;
   final String label;
@@ -486,25 +529,31 @@ class _ActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final enabled = onTap != null;
-    final color = enabled ? _kInk : const Color(0xFFB0A89A);
+    final iconColor = enabled ? _kBtnPrimary : const Color(0xFFBBAA9A);
+    final textColor = enabled ? _kInk : const Color(0xFFBBAA9A);
+    final borderColor = enabled ? _kBtnPrimary : const Color(0xFFCCC4B4);
+    final bgColor = enabled ? const Color(0xFFFAF0E6) : const Color(0xFFF5EDE4);
 
     return GestureDetector(
       onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 10),
         decoration: BoxDecoration(
-          color: enabled ? const Color(0xFFE8D5B0) : const Color(0xFFF0E8DA),
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(
-            color: enabled ? _kGold : const Color(0xFFCCC4B4),
-            width: 1,
-          ),
+          color: bgColor,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: borderColor, width: enabled ? 1.5 : 1),
           boxShadow: enabled
               ? [
                   BoxShadow(
-                    color: _kGold.withValues(alpha: 0.2),
-                    blurRadius: 4,
-                    offset: const Offset(0, 2),
+                    color: _kBtnPrimary.withValues(alpha: 0.18),
+                    blurRadius: 6,
+                    offset: const Offset(0, 3),
+                  ),
+                  const BoxShadow(
+                    color: Color(0x20000000),
+                    blurRadius: 2,
+                    offset: Offset(0, 1),
                   ),
                 ]
               : null,
@@ -512,19 +561,67 @@ class _ActionButton extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(icon, size: 22, color: color),
-            const SizedBox(height: 2),
+            Icon(icon, size: 24, color: iconColor),
+            const SizedBox(height: 4),
             Text(
               label,
               style: TextStyle(
                 fontSize: 12,
-                color: color,
+                color: textColor,
                 fontWeight: FontWeight.bold,
                 letterSpacing: 2,
               ),
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// 游戏页内主按钮（暂停遮罩使用）
+class _GamePrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onPressed;
+
+  const _GamePrimaryButton({required this.label, this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [_kBtnPrimaryLight, _kBtnPrimary, _kBtnPrimaryDark],
+        ),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: _kBtnOutlineBorder, width: 1.5),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x60922B21),
+            blurRadius: 12,
+            offset: Offset(0, 4),
+          ),
+        ],
+      ),
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Colors.transparent,
+          shadowColor: Colors.transparent,
+          foregroundColor: _kParchment,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
+          textStyle: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+            letterSpacing: 4,
+          ),
+        ),
+        onPressed: onPressed,
+        child: Text(label),
       ),
     );
   }

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -8,6 +8,15 @@ const _kGold = Color(0xFF8B6914);
 const _kGoldLight = Color(0xFFD4A84B);
 const _kBamboo = Color(0xFFE8D5B0);
 
+/// 按钮主色：深朱红（主按钮）
+const _kBtnPrimary = Color(0xFFC0392B);
+const _kBtnPrimaryDark = Color(0xFF922B21);
+const _kBtnPrimaryLight = Color(0xFFE74C3C);
+
+/// 按钮次色：描金镂空（次按钮）
+const _kBtnOutlineBorder = Color(0xFFD4A84B);
+const _kBtnOutlineText = Color(0xFFD4A84B);
+
 class HomeView extends StatelessWidget {
   const HomeView({super.key});
 
@@ -74,59 +83,21 @@ class HomeView extends StatelessWidget {
 
               const Spacer(flex: 3),
 
-              // 开始游戏按钮
+              // 开始游戏按钮（主按钮：深朱红渐变 + 金边 + 大阴影）
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 48),
-                child: SizedBox(
-                  width: double.infinity,
-                  height: 54,
-                  child: ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: _kGold,
-                      foregroundColor: _kParchment,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                        side: const BorderSide(color: _kGoldLight, width: 1),
-                      ),
-                      elevation: 8,
-                      shadowColor: const Color(0x80000000),
-                      textStyle: const TextStyle(
-                        fontSize: 20,
-                        fontWeight: FontWeight.bold,
-                        letterSpacing: 8,
-                      ),
-                    ),
-                    onPressed: () => Get.toNamed('/game'),
-                    child: const Text('开始对弈'),
-                  ),
+                child: _PrimaryButton(
+                  label: '开始对弈',
+                  onPressed: () => Get.toNamed('/game'),
                 ),
               ),
               const SizedBox(height: 16),
-              // 游戏规则按钮
+              // 游戏规则按钮（次按钮：描金镂空）
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 48),
-                child: SizedBox(
-                  width: double.infinity,
-                  height: 54,
-                  child: OutlinedButton(
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: _kBamboo,
-                      side: BorderSide(
-                        color: _kBamboo.withValues(alpha: 0.4),
-                        width: 1,
-                      ),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      textStyle: const TextStyle(
-                        fontSize: 20,
-                        fontWeight: FontWeight.bold,
-                        letterSpacing: 8,
-                      ),
-                    ),
-                    onPressed: () => _showRulesDialog(context),
-                    child: const Text('棋谱规则'),
-                  ),
+                child: _SecondaryButton(
+                  label: '棋谱规则',
+                  onPressed: () => _showRulesDialog(context),
                 ),
               ),
 
@@ -220,10 +191,109 @@ class HomeView extends StatelessWidget {
         ),
         actions: [
           TextButton(
+            style: TextButton.styleFrom(
+              foregroundColor: _kBtnPrimary,
+              textStyle: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                letterSpacing: 4,
+              ),
+            ),
             onPressed: () => Get.back(),
             child: const Text('知晓'),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// 主按钮：深朱红渐变背景 + 金边描边 + 阴影
+class _PrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onPressed;
+
+  const _PrimaryButton({required this.label, this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 56,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: const LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [_kBtnPrimaryLight, _kBtnPrimary, _kBtnPrimaryDark],
+          ),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: _kBtnOutlineBorder, width: 1.5),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x60922B21),
+              blurRadius: 12,
+              offset: Offset(0, 4),
+            ),
+            BoxShadow(
+              color: Color(0x30000000),
+              blurRadius: 4,
+              offset: Offset(0, 2),
+            ),
+          ],
+        ),
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.transparent,
+            shadowColor: Colors.transparent,
+            foregroundColor: _kParchment,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+            textStyle: const TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              letterSpacing: 8,
+            ),
+          ),
+          onPressed: onPressed,
+          child: Text(label),
+        ),
+      ),
+    );
+  }
+}
+
+/// 次按钮：金色描边镂空
+class _SecondaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onPressed;
+
+  const _SecondaryButton({required this.label, this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 56,
+      child: OutlinedButton(
+        style: OutlinedButton.styleFrom(
+          foregroundColor: _kBtnOutlineText,
+          side: const BorderSide(color: _kBtnOutlineBorder, width: 1.5),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+          backgroundColor: const Color(0x15D4A84B),
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+          textStyle: const TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            letterSpacing: 8,
+          ),
+        ),
+        onPressed: onPressed,
+        child: Text(label),
       ),
     );
   }

--- a/lib/views/piece_widget.dart
+++ b/lib/views/piece_widget.dart
@@ -45,21 +45,28 @@ class PieceWidget extends StatelessWidget {
     final textColor = isRed ? const Color(0xFFA01010) : const Color(0xFF1A1A1A);
     final name = getPieceName(piece.type, piece.side);
 
+    // 红方：朱砂暖红；黑方：玄墨深棕
+    final normalColors = isRed
+        ? [const Color(0xFFFFE0D0), const Color(0xFFCC5A3A)]
+        : [const Color(0xFFD8D0C0), const Color(0xFF6A5040)];
+    final borderColor = isRed
+        ? const Color(0xFF8B2010)
+        : const Color(0xFF3A2810);
+
     return Container(
       width: size,
       height: size,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        // 木质棋子渐变底色
         gradient: RadialGradient(
           center: const Alignment(-0.2, -0.3),
           radius: 0.9,
           colors: isSelected
               ? [const Color(0xFFFFF3D6), const Color(0xFFE8C878)]
-              : [const Color(0xFFF7E8C8), const Color(0xFFD4B47A)],
+              : normalColors,
         ),
         border: Border.all(
-          color: isSelected ? const Color(0xFFD4A84B) : const Color(0xFF6B3A1F),
+          color: isSelected ? const Color(0xFFD4A84B) : borderColor,
           width: isSelected ? 2.5 : 1.5,
         ),
         boxShadow: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -452,10 +452,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -665,10 +665,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timing:
     dependency: transitive
     description:

--- a/tools/linear-github-bridge/src/index.ts
+++ b/tools/linear-github-bridge/src/index.ts
@@ -22,7 +22,17 @@ export default {
     }
 
     if (url.pathname === '/health') {
-      return new Response(JSON.stringify({ status: 'ok', time: new Date().toISOString() }), {
+      return new Response(JSON.stringify({
+        status: 'ok',
+        time: new Date().toISOString(),
+        secrets: {
+          LINEAR_WEBHOOK_SECRET: env.LINEAR_WEBHOOK_SECRET ? `set (${env.LINEAR_WEBHOOK_SECRET.length} chars)` : 'MISSING',
+          LINEAR_API_KEY: env.LINEAR_API_KEY ? `set (${env.LINEAR_API_KEY.length} chars)` : 'MISSING',
+          GITHUB_TOKEN: env.GITHUB_TOKEN ? `set (${env.GITHUB_TOKEN.length} chars)` : 'MISSING',
+          SLACK_SIGNING_SECRET: env.SLACK_SIGNING_SECRET ? `set (${env.SLACK_SIGNING_SECRET.length} chars)` : 'MISSING',
+          GITHUB_REPO: env.GITHUB_REPO ?? 'MISSING',
+        },
+      }), {
         headers: { 'Content-Type': 'application/json' },
       });
     }

--- a/tools/linear-github-bridge/src/linear-to-github.ts
+++ b/tools/linear-github-bridge/src/linear-to-github.ts
@@ -60,7 +60,18 @@ export async function handleLinearWebhook(
   // 2. 解析并过滤事件
   const payload: LinearWebhookPayload = JSON.parse(body);
 
+  // 调试日志 — 查看 Linear 实际发送的数据
+  console.log('LINEAR WEBHOOK:', JSON.stringify({
+    action: payload.action,
+    type: payload.type,
+    stateType: payload.data?.state?.type,
+    stateName: payload.data?.state?.name,
+    title: payload.data?.title,
+    labels: payload.data?.labels,
+  }));
+
   if (payload.type !== 'Issue') {
+    console.log('SKIPPED: not an issue, type =', payload.type);
     return new Response('Skipped: not an issue event', { status: 200 });
   }
 
@@ -71,6 +82,8 @@ export async function handleLinearWebhook(
   const hasReadyLabel = payload.data.labels?.some(
     (l) => l.name.toLowerCase() === 'ready-for-claude',
   );
+
+  console.log('FILTER CHECK:', { isInProgress, hasReadyLabel, action: payload.action, stateType: payload.data.state?.type });
 
   if (!isInProgress && !hasReadyLabel) {
     return new Response('Skipped: event filtered', { status: 200 });


### PR DESCRIPTION
## 改动内容

### 首页按钮 (`home_view.dart`)
- **主按钮「开始对弈」**：朱红三段渐变背景 + 1.5px 金色描边 + 双层阴影，高度 56，字号 20
- **次按钮「棋谱规则」**：金色镂空描边 + 半透明底色，与主按钮形成主次区分
- 规则弹框「知晓」按钮：朱红前景色，letterSpacing 4

### 游戏页按钮 (`game_view.dart`)
- **暂停遮罩「继续对弈」**：朱红渐变 + 金色描边，替换原纯金色背景
- **底部功能按钮**（重玩/提示/悔棋）：启用态朱红描边 + 阴影；禁用态淡灰色
- **各弹框文字按钮**：确认操作用朱红，取消操作用金色，形成明确的权重区分

### 设计风格
朱红（`#C0392B` / `#922B21` / `#E74C3C`）+ 金色（`#D4A84B`）双色系，符合中国传统棋类游戏视觉语言

## 测试计划
- [ ] 首页两个主按钮视觉效果确认
- [ ] 暂停/结束/返回弹框按钮交互正常
- [ ] 底部功能按钮禁用状态视觉正确